### PR TITLE
Fix product edit page layout

### DIFF
--- a/frontend/src/pages/ProductFormPage.jsx
+++ b/frontend/src/pages/ProductFormPage.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Row, Col, Card, Button } from 'react-bootstrap';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import ProductDetailForm from '../components/products/ProductDetailForm';
+import '../styles/pages/products.css';
 
 const ProductFormPage = () => {
   const navigate = useNavigate();
@@ -19,7 +20,7 @@ const ProductFormPage = () => {
   };
 
   return (
-    <div className="product-page-wrapper" style={{ paddingTop: '4rem' }}>
+    <div className="product-page-wrapper">
       <Row className="mb-4">
         <Col lg={10} className="mx-auto d-flex justify-content-between align-items-center">
           <h1 style={{ 

--- a/frontend/src/styles/pages/products.css
+++ b/frontend/src/styles/pages/products.css
@@ -188,8 +188,10 @@
 
 /* Estilos mejorados para la vista de productos */
 .product-page-wrapper {
-  padding: var(--space-4);
-  max-width: 100%;
+  padding: var(--content-padding);
+  background-color: var(--bg-surface-2);
+  min-height: calc(100vh - var(--navbar-height));
+  width: 100%;
 }
 
 /* Estilos para la cuadrícula de productos */


### PR DESCRIPTION
## Summary
- import product CSS in `ProductFormPage`
- remove inline padding and rely on class styles
- expand `.product-page-wrapper` styles so the edit page fills available space

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6870180c2aa08332ad50a49a8ff29058