### PR TITLE
Fix product edit layout height

### DIFF
--- a/frontend/src/pages/ProductFormPage.jsx
+++ b/frontend/src/pages/ProductFormPage.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Row, Col, Card, Button } from 'react-bootstrap';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import ProductDetailForm from '../components/products/ProductDetailForm';
+import '../styles/pages/products.css';
 
 const ProductFormPage = () => {
   const navigate = useNavigate();
@@ -19,7 +20,7 @@ const ProductFormPage = () => {
   };
 
   return (
-    <div className="product-page-wrapper" style={{ paddingTop: '4rem' }}>
+    <div className="product-page-wrapper">
       <Row className="mb-4">
         <Col lg={10} className="mx-auto d-flex justify-content-between align-items-center">
           <h1 style={{ 

--- a/frontend/src/styles/core/tokens.css
+++ b/frontend/src/styles/core/tokens.css
@@ -95,5 +95,7 @@
   /* === LAYOUT VARIABLES === */
   --sidebar-width: 240px;
   --header-height: 60px;
+  /* Altura de la barra superior (por defecto usa la altura del header) */
+  --navbar-height: var(--header-height);
   --content-padding: var(--space-6);
 }

--- a/frontend/src/styles/pages/products.css
+++ b/frontend/src/styles/pages/products.css
@@ -188,8 +188,10 @@
 
 /* Estilos mejorados para la vista de productos */
 .product-page-wrapper {
-  padding: var(--space-4);
-  max-width: 100%;
+  padding: var(--content-padding);
+  background-color: var(--bg-surface-2);
+  min-height: calc(100vh - var(--navbar-height));
+  width: 100%;
 }
 
 /* Estilos para la cuadrícula de productos */


### PR DESCRIPTION
## Summary
- define `--navbar-height` based on the header height
- ensure product edit page imports its styles

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6870180c2aa08332ad50a49a8ff29058