### PR TITLE
Use MASTER_ENCRYPTION_KEY from environment

### DIFF
--- a/backend/CREDENTIALS-SECURITY.md
+++ b/backend/CREDENTIALS-SECURITY.md
@@ -64,6 +64,14 @@ O en tu archivo `.env`:
 ENCRYPTION_PASSWORD=tu-contraseña-super-segura
 ```
 
+### Clave maestra para doble encriptación
+Algunos scripts como `check-credentials.js` y los ubicados en `backend/scripts/` utilizan una segunda clave llamada `MASTER_ENCRYPTION_KEY`.
+Esta variable **debe** configurarse en el entorno y no tiene valor por defecto.
+
+```bash
+export MASTER_ENCRYPTION_KEY="tu-clave-maestra"
+```
+
 ## 🛠️ Scripts disponibles
 
 ### Encriptar credenciales (ya ejecutado)

--- a/backend/scripts/doubleEncryption.js
+++ b/backend/scripts/doubleEncryption.js
@@ -145,8 +145,8 @@ async function createDoubleEncryptedCredentials(credentialType = 'google') {
     throw new Error(`Tipo de credencial no válido: ${credentialType}`);
   }
   
-  // Clave maestra (se debe configurar en .env)
-  const masterPassword = process.env.MASTER_ENCRYPTION_KEY || 'fisgo-monkey-tech-master-key-2025';
+  // Clave maestra (obligatoria en variable de entorno)
+  const masterPassword = process.env.MASTER_ENCRYPTION_KEY;
   
   try {
     // Leer credenciales originales

--- a/backend/scripts/encryptFirebaseCredentials.js
+++ b/backend/scripts/encryptFirebaseCredentials.js
@@ -98,8 +98,8 @@ async function createFirebaseDoubleEncryptedCredentials() {
   const inputFile = path.join(__dirname, '../config/firebase-service-account.json');
   const outputFile = path.join(__dirname, '../config/firebase-credentials.double-encrypted.json');
   
-  // Clave maestra (se debe configurar en .env)
-  const masterPassword = process.env.MASTER_ENCRYPTION_KEY || 'fisgo-monkey-tech-master-key-2025';
+  // Clave maestra (obligatoria en variable de entorno)
+  const masterPassword = process.env.MASTER_ENCRYPTION_KEY;
   
   try {
     // Leer credenciales originales

--- a/check-credentials.js
+++ b/check-credentials.js
@@ -6,8 +6,8 @@ const { DoubleEncryptionManager } = require('./backend/scripts/doubleEncryption'
 const encryptedFilePath = path.join(__dirname, 'backend/config/google-credentials.double-encrypted.json');
 const doubleEncryptedData = JSON.parse(fs.readFileSync(encryptedFilePath, 'utf8'));
 
-// Usar la clave maestra del .env
-const masterPassword = 'fisgo-monkey-tech-master-key-2025'; // Desde el .env del backend
+// Usar la clave maestra desde la variable de entorno
+const masterPassword = process.env.MASTER_ENCRYPTION_KEY;
 
 const doubleEncryption = new DoubleEncryptionManager();
 


### PR DESCRIPTION
## Summary
- rely on `process.env.MASTER_ENCRYPTION_KEY` in credential scripts
- document `MASTER_ENCRYPTION_KEY` requirement

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870a7646ea88332a520d2fceeb34851